### PR TITLE
Correct spelling of Cocoapods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ imageView.imageWithString(word: "Ridvan Kucuk", color: nil, circular: true)
 
 You can just drag and drop UIImageView+Words.swift file into your project.
 
-## Cocoapods Installation
+## CocoaPods Installation
 
 UIImageViewWithWords is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
